### PR TITLE
Lead with Howell & Gibbs studio and make demos hover-only

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <title>Liam Howell | Builder</title>
+        <title>Liam Howell | Howell &amp; Gibbs</title>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="description" content="Software engineer turned founder. Building SendTax.">
+        <meta name="description" content="Software engineer and co-founder of Howell &amp; Gibbs, a studio building civic and public-good products.">
         <meta name="author" content="Liam Howell">
 
         <link rel="apple-touch-icon" sizes="57x57" href="images/apple-touch-icon-57x57.png">
@@ -51,10 +51,11 @@
                     <section class="about">
                         <h2>Hey there</h2>
                         <p>
-                            I'm a software engineer turned founder, currently building
-                            <a href="https://send.tax">SendTax</a> &mdash; drop in your
-                            tax documents and it tells you exactly what you still need.
-                            Previously I spent years building software at places like
+                            I run <a href="https://howellandgibbs.com">Howell &amp; Gibbs</a>
+                            with Holly Gibbs &mdash; a small studio building civic and
+                            public-good products like <a href="https://send.tax">SendTax</a>
+                            and <a href="https://govroll.com">Govroll</a>. Before the
+                            studio I spent years writing software at places like
                             <a href="https://guideline.com">Guideline</a>.
                             Outside of work, I'm usually cooking or spending time with family.
                         </p>

--- a/src/js/govroll-demo.js
+++ b/src/js/govroll-demo.js
@@ -1,6 +1,7 @@
 /**
  * Govroll demo loop
  * Bill slides in -> 50 rep dots cascade-flip green/red -> tally settles.
+ * Animates only while the card is hovered or focused.
  */
 (function () {
     var BILLS = [
@@ -19,6 +20,7 @@
         var stage = document.getElementById('govroll-stage');
         if (!stage) return;
 
+        var card = stage.closest('.project-card') || stage;
         var billId = stage.querySelector('[data-gr="bill-id"]');
         var billTitle = stage.querySelector('[data-gr="bill-title"]');
         var grid = stage.querySelector('[data-gr="grid"]');
@@ -34,32 +36,8 @@
         }
         var cells = grid.querySelectorAll('.gr-cell');
 
-        var visible = true;
-        var inView = true;
-        document.addEventListener('visibilitychange', function () {
-            visible = !document.hidden;
-        });
-        if ('IntersectionObserver' in window) {
-            var io = new IntersectionObserver(function (entries) {
-                inView = entries[0] && entries[0].isIntersecting;
-            }, { threshold: 0.15 });
-            io.observe(stage);
-        }
-
         function delay(ms) {
             return new Promise(function (r) { setTimeout(r, ms); });
-        }
-
-        function waitForReady() {
-            if (visible && inView) return Promise.resolve();
-            return new Promise(function (resolve) {
-                var t = setInterval(function () {
-                    if (visible && inView) {
-                        clearInterval(t);
-                        resolve();
-                    }
-                }, 250);
-            });
         }
 
         function reset() {
@@ -96,10 +74,13 @@
             return order;
         }
 
-        async function loop() {
-            var billIdx = 0;
-            while (true) {
-                await waitForReady();
+        // Token bumped on every start/stop. Live loops check it after each
+        // await and bail if it changed — that's how we cancel mid-animation.
+        var token = 0;
+        var billIdx = 0;
+
+        async function loop(myToken) {
+            while (myToken === token) {
                 reset();
 
                 var bill = BILLS[billIdx % BILLS.length];
@@ -107,11 +88,10 @@
                 billId.textContent = bill.id;
                 billTitle.textContent = bill.title;
 
-                // Bill slides in
                 stage.classList.add('gr-state-bill');
                 await delay(900);
+                if (myToken !== token) return;
 
-                // Start voting
                 stage.classList.add('gr-state-voting');
                 var order = buildVoteOrder(bill.yeaRate);
                 var yea = 0, nay = 0;
@@ -128,9 +108,9 @@
                         nayEl.textContent = String(nay);
                     }
                     await delay(40);
+                    if (myToken !== token) return;
                 }
 
-                // Result stamp
                 var passed = yea > nay;
                 resultEl.textContent = passed ? 'PASSED' : 'FAILED';
                 stage.classList.add(passed ? 'gr-state-passed' : 'gr-state-failed', 'gr-state-done');
@@ -138,7 +118,20 @@
             }
         }
 
-        loop();
+        function start() {
+            var myToken = ++token;
+            loop(myToken);
+        }
+
+        function stop() {
+            token++;
+            reset();
+        }
+
+        card.addEventListener('pointerenter', start);
+        card.addEventListener('pointerleave', stop);
+        card.addEventListener('focusin', start);
+        card.addEventListener('focusout', stop);
     }
 
     if (document.readyState === 'loading') {

--- a/src/js/sendtax-demo.js
+++ b/src/js/sendtax-demo.js
@@ -1,35 +1,19 @@
 /**
  * SendTax demo loop
  * Drop a doc -> scan -> classify -> checklist fills.
+ * Animates only while the card is hovered or focused.
  */
 (function () {
     function setup() {
         var stage = document.getElementById('sendtax-stage');
         if (!stage) return;
 
-        var doc = stage.querySelector('[data-st="doc"]');
-        var dz = stage.querySelector('[data-st="dropzone"]');
-        var scan = stage.querySelector('[data-st="scan"]');
-        var badge = stage.querySelector('[data-st="badge"]');
+        var card = stage.closest('.project-card') || stage;
         var items = stage.querySelectorAll('[data-st-item]');
 
         function reset() {
             stage.classList.remove('st-state-drop', 'st-state-scan', 'st-state-classified', 'st-state-listing', 'st-state-done');
             items.forEach(function (li) { li.classList.remove('is-checked'); });
-        }
-
-        // Pause when offscreen / tab hidden.
-        var visible = true;
-        var inView = true;
-        document.addEventListener('visibilitychange', function () {
-            visible = !document.hidden;
-        });
-
-        if ('IntersectionObserver' in window) {
-            var io = new IntersectionObserver(function (entries) {
-                inView = entries[0] && entries[0].isIntersecting;
-            }, { threshold: 0.15 });
-            io.observe(stage);
         }
 
         function step(state, ms) {
@@ -39,38 +23,49 @@
             });
         }
 
-        function waitForReady() {
-            if (visible && inView) return Promise.resolve();
-            return new Promise(function (resolve) {
-                var t = setInterval(function () {
-                    if (visible && inView) {
-                        clearInterval(t);
-                        resolve();
-                    }
-                }, 250);
-            });
-        }
+        // Token bumped on every start/stop. Live loops check it after each
+        // await and bail if it changed — that's how we cancel mid-animation.
+        var token = 0;
 
-        async function loop() {
-            while (true) {
-                await waitForReady();
+        async function loop(myToken) {
+            while (myToken === token) {
                 reset();
-                await step(null, 700);                  // settle
-                await step('st-state-drop', 1100);      // doc travels into dropzone
-                await step('st-state-scan', 1400);      // scan line sweeps
-                await step('st-state-classified', 1100); // badge pops
+                await step(null, 700);
+                if (myToken !== token) return;
+                await step('st-state-drop', 1100);
+                if (myToken !== token) return;
+                await step('st-state-scan', 1400);
+                if (myToken !== token) return;
+                await step('st-state-classified', 1100);
+                if (myToken !== token) return;
                 stage.classList.add('st-state-listing');
                 await step(null, 250);
+                if (myToken !== token) return;
                 items[0].classList.add('is-checked');
                 await step(null, 500);
+                if (myToken !== token) return;
                 items[1].classList.add('is-checked');
                 await step(null, 500);
+                if (myToken !== token) return;
                 items[2].classList.add('is-checked');
                 await step('st-state-done', 1800);
             }
         }
 
-        loop();
+        function start() {
+            var myToken = ++token;
+            loop(myToken);
+        }
+
+        function stop() {
+            token++;
+            reset();
+        }
+
+        card.addEventListener('pointerenter', start);
+        card.addEventListener('pointerleave', stop);
+        card.addEventListener('focusin', start);
+        card.addEventListener('focusout', stop);
     }
 
     if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary

- Reframe the bio around **Howell & Gibbs** (howellandgibbs.com) — the studio I'm launching with Holly Gibbs. SendTax and Govroll now appear as the studio's current products instead of standalone bets.
- Convert the SendTax and Govroll demo loops from auto-playing-while-visible to **hover-only**. Each card starts its loop on `pointerenter`/`focusin` and resets to a clean stage on `pointerleave`/`focusout`.
- Update the page `<title>` and meta description to match.

## Why

The auto-looping animations pulled focus from the bio and burned cycles whenever the cards were on-screen. The bio reframing also means SendTax and Govroll are now the studio's products, not the headline themselves — so a quieter default state is the right call.

## Notable

- Cancellation uses a generation token (bumped on both start and stop). Each `await` checkpoint in the loop checks whether its token still matches; if not, it returns. That cleans up mid-step leaves without leaving the stage in a half-state.
- Removed the `IntersectionObserver` + `visibilitychange` gating — no longer needed now that animations only run during hover.
- Touch devices won't trigger the animations at all (no hover, and tapping the card navigates). That's intentional given the brief.
- `focusin`/`focusout` keep keyboard users covered.

## Test plan

- [ ] Open the page — both cards sit at rest, no animation classes applied
- [ ] Hover SendTax — doc drops, scan sweeps, badge pops, checklist fills
- [ ] Mouse off mid-animation — stage resets cleanly with no stuck classes
- [ ] Hover Govroll — bill appears, vote cells cascade, result stamps
- [ ] Tab to a card with the keyboard — animation starts on focus, stops on blur
- [ ] Header still cycles colors on click; high-five emoji still works